### PR TITLE
blueprint: Use new constructor format

### DIFF
--- a/tensorFlow.js
+++ b/tensorFlow.js
@@ -16,8 +16,7 @@ function main() {
   const src = fs.readFileSync(srcPath, { encoding: 'utf8' });
 
   const infra = kelda.baseInfrastructure();
-  const nWorkerMachines = infra.machines.filter(m => m.role === 'Worker').length;
-  const containers = makeContainers(src, 1, nWorkerMachines - 1);
+  const containers = makeContainers(src, 1, infra.workers.length - 1);
   containers.forEach((c) => {
     c.deploy(infra);
   });
@@ -68,7 +67,9 @@ function makeContainers(jobSource, nPs, nWorker) {
 function makeJobContainers(jobSource, jobName, n) {
   const containers = [];
   for (let i = 0; i < n; i += 1) {
-    containers.push(new kelda.Container(jobName, 'keldaio/tensorflow', {
+    containers.push(new kelda.Container({
+      name: jobName,
+      image: 'keldaio/tensorflow',
       command: ['python', '/usr/src/app/main.py',
         '--job_name', jobName, '--task_index', i.toString()],
       filepathToContent: {

--- a/testInfra.js
+++ b/testInfra.js
@@ -1,7 +1,10 @@
 // This file contains the base infrastructure used for the travis build.
 function infraGetter(kelda) {
   const vmTemplate = new kelda.Machine({ provider: 'Amazon' });
-  const infra = new kelda.Infrastructure(vmTemplate, vmTemplate.replicate(2));
+  const infra = new kelda.Infrastructure({
+    masters: vmTemplate,
+    workers: vmTemplate.replicate(2),
+  });
   return infra;
 }
 


### PR DESCRIPTION
The build will fail until the next release of Kelda (0.10.0). This should not be merged until then.